### PR TITLE
Refactor constants

### DIFF
--- a/src/modules/canvas/CanvasDisplay.lua
+++ b/src/modules/canvas/CanvasDisplay.lua
@@ -1,11 +1,12 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local ImageDataConstructor = require(ReplicatedStorage.Modules.Canvas.ImageDataConstructor)
 local DebugUtils = require(ReplicatedStorage.Modules.Services.DebugUtils)
+local GameConfig = require(ReplicatedStorage.Modules.GameData.GameConfig)
 local TweenService = game:GetService("TweenService")
 local RunService = game:GetService("RunService")
 
 local CanvasDisplay = {}
-local DebugFlag = false
+local DebugFlag = GameConfig.DEBUG_INPUTUTILS
 
 -- Debug logging function using DebugUtils
 --- Logs a message to the console if DebugFlag is enabled.
@@ -17,8 +18,8 @@ local function log(...)
 end
 
 -- Sound effect for trophy appearance
-local TROPHY_SOUND_ID = "rbxassetid://111277558339395"
-local HIGH_SCORE_SOUND_ID = "rbxassetid://79723856625266" -- Add a celebration sound for high scores
+local TROPHY_SOUND_ID = GameConfig.TROPHY_SOUND_ID
+local HIGH_SCORE_SOUND_ID = GameConfig.HIGH_SCORE_SOUND_ID -- Add a celebration sound for high scores
 local soundsFolder = ReplicatedStorage:FindFirstChild("Sounds")
 assert(soundsFolder ~= nil, "Sounds folder not found in ReplicatedStorage")
 

--- a/src/modules/gameData/GameConfig.lua
+++ b/src/modules/gameData/GameConfig.lua
@@ -5,6 +5,11 @@ local GameConfig = {
     THEME_LIST_LIMIT = 100,
     THEME_LIST_ROWS_PER_PAGE = 20,
     SELECTED_COLOR = Color3.fromRGB(128, 208, 255),
+
+    -- Client side configurable constants
+    TROPHY_SOUND_ID = "rbxassetid://111277558339395",
+    HIGH_SCORE_SOUND_ID = "rbxassetid://79723856625266",
+    DEBUG_INPUTUTILS = true,
 }
 
 return GameConfig

--- a/src/modules/utils/InputUtils.luau
+++ b/src/modules/utils/InputUtils.luau
@@ -1,9 +1,10 @@
 local UIS = game:GetService("UserInputService")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local DebugUtils  = require(ReplicatedStorage.Modules.Services.DebugUtils)
+local GameConfig = require(ReplicatedStorage.Modules.GameData.GameConfig)
 local InputUtils = {}
 
-local DebugFlag = true
+local DebugFlag = GameConfig.DEBUG_INPUTUTILS
 local function log(...)
     if DebugFlag then DebugUtils.print("DrawingCanvas:", ...) end
 end

--- a/src/server/AdminCommandHandler.server.lua
+++ b/src/server/AdminCommandHandler.server.lua
@@ -1,9 +1,9 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local Events = ReplicatedStorage:WaitForChild("Events")
+local ServerScriptService = game:GetService("ServerScriptService")
+local ServerConfig = require(ServerScriptService.modules.ServerConfig)
 -- Define authorized admin UserIds
-local AdminUserIds = {
-    [8240890430] = true, -- your user id here
-}
+local AdminUserIds = ServerConfig.ADMIN_USER_IDS
 local function packValue(userId, playerName, points)
     -- Anything you want to keep for the row can live in here
     return {

--- a/src/server/ClearData.server.lua
+++ b/src/server/ClearData.server.lua
@@ -6,9 +6,11 @@ local HASH_MAPS   = {}
 -- INTERNAL CONSTANTS
 -------------------------------------------------------------------
 local MS             = game:GetService("MemoryStoreService")
-local BATCH_SIZE     = 100            -- max items to fetch per call
-local YIELD_SECONDS  = 0.10           -- small pause between batches
-local MAX_RETRIES    = 5              -- retry on transient InternalError
+local ServerScriptService = game:GetService("ServerScriptService")
+local ServerConfig = require(ServerScriptService.modules.ServerConfig)
+local BATCH_SIZE     = ServerConfig.CLEAR_DATA.BATCH_SIZE            -- max items to fetch per call
+local YIELD_SECONDS  = ServerConfig.CLEAR_DATA.YIELD_SECONDS           -- small pause between batches
+local MAX_RETRIES    = ServerConfig.CLEAR_DATA.MAX_RETRIES              -- retry on transient InternalError
 
 -------------------------------------------------------------------
 -- HELPER: safe MemoryStore call with exponential back-off

--- a/src/server/GameManager.server.lua
+++ b/src/server/GameManager.server.lua
@@ -22,7 +22,8 @@ local CanvasManager = require(ServerScriptService.modules.CanvasManager)
 -- Remote events
 local Events = ReplicatedStorage:WaitForChild("Events")
 
-local DEBUG_ENABLED = true
+local ServerConfig = require(ServerScriptService.modules.ServerConfig)
+local DEBUG_ENABLED = ServerConfig.DEBUG_ENABLED
 
 local function getDifficultyMultiplier(difficulty: string)
     if difficulty == "Easy" then

--- a/src/server/ProximityPromptController.server.lua
+++ b/src/server/ProximityPromptController.server.lua
@@ -1,6 +1,7 @@
 local CollectionService = game:GetService("CollectionService")
 local ServerScriptService = game:GetService("ServerScriptService")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local ServerConfig = require(ServerScriptService.modules.ServerConfig)
 local ServerStates = require(ServerScriptService.modules.ServerStates)
 local GameConstants = require(ReplicatedStorage.Modules.GameData.GameConstants)
 local Events = ReplicatedStorage:WaitForChild("Events")
@@ -15,8 +16,8 @@ local function attachDrawingPrompts(canvasModel)
     local prompt = Instance.new("ProximityPrompt")
     prompt.Name = "RegisterCanvasPrompt"
     prompt.RequiresLineOfSight   = false
-    prompt.HoldDuration          = 0.5
-    prompt.MaxActivationDistance = 5 
+    prompt.HoldDuration          = ServerConfig.PROMPT.HOLD_DURATION
+    prompt.MaxActivationDistance = ServerConfig.PROMPT.MAX_ACTIVATION_DISTANCE
     prompt.ActionText            = "Claim"   -- we'll show our own SurfaceGui
     prompt.ObjectText            = "Canvas"
     prompt.Parent = board
@@ -24,8 +25,8 @@ local function attachDrawingPrompts(canvasModel)
     CollectionService:AddTag(prompt, "CanvasPrompt")
 end
 
-local TELEPORT_DISTANCE = 2   -- studs in front of the board
-local TELEPORT_HEIGHT   = 0    -- studs up
+local TELEPORT_DISTANCE = ServerConfig.PROMPT.TELEPORT_DISTANCE   -- studs in front of the board
+local TELEPORT_HEIGHT   = ServerConfig.PROMPT.TELEPORT_HEIGHT    -- studs up
 
 local function teleportPlayerToCanvas(player, canvasModel)
     local char = player.Character

--- a/src/server/modules/BackendService.luau
+++ b/src/server/modules/BackendService.luau
@@ -5,10 +5,11 @@
 local HttpService = game:GetService("HttpService")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local ServerScriptService = game:GetService("ServerScriptService")
+local ServerConfig = require(ServerScriptService.modules.ServerConfig)
 local CanvasDraw = require(ReplicatedStorage.Modules.Canvas.CanvasDraw)
 local SchemaValidator = require(ServerScriptService.modules.SchemaValidator)
 local BackendService = {}
-local DEBUG_ENABLED = true
+local DEBUG_ENABLED = ServerConfig.DEBUG_ENABLED
 
 -- Debug print function that only outputs when debugging is enabled
 local function debugPrint(message, ...)
@@ -18,11 +19,10 @@ local function debugPrint(message, ...)
 end
 
 -- Configuration
-BackendService.BaseUrl = "https://drawing-backend.vercel.app"
--- BackendService.BaseUrl = "http://localhost:3000"
+BackendService.BaseUrl = ServerConfig.BACKEND_BASE_URL
 BackendService.Endpoints = {
-    OPENAI = "/api/openai",
-    FEEDBACK = "/api/feedback"
+    OPENAI = ServerConfig.OPENAI_ENDPOINT,
+    FEEDBACK = ServerConfig.FEEDBACK_ENDPOINT,
 }
 
 -- Default options for requests

--- a/src/server/modules/PlayerBestDrawingsStore.luau
+++ b/src/server/modules/PlayerBestDrawingsStore.luau
@@ -3,11 +3,12 @@ local ServerScriptService = game:GetService("ServerScriptService")
 local DataStoreHelper = require(ServerScriptService.modules.DataStoreHelper)
 local HttpService = game:GetService("HttpService")
 local SchemaValidator = require(ServerScriptService.modules.SchemaValidator)
+local ServerConfig = require(ServerScriptService.modules.ServerConfig)
 local PlayerBestDrawingsDataStore = DataStoreService:GetDataStore("PlayerBestDrawings")
 local ThemeStore = require(ServerScriptService.modules.ThemeStore)
 
 local PlayerBestDrawingsStore = {}
-local DEBUG_ENABLED = true
+local DEBUG_ENABLED = ServerConfig.DEBUG_ENABLED
 
 -- Debug print function that only outputs when debugging is enabled
 local function debugPrint(message, ...)

--- a/src/server/modules/PlayerStore.luau
+++ b/src/server/modules/PlayerStore.luau
@@ -2,17 +2,18 @@ local DataStoreService = game:GetService("DataStoreService")
 local ServerScriptService = game:GetService("ServerScriptService")
 local DataStoreHelper = require(ServerScriptService.modules.DataStoreHelper)
 local SchemaValidator = require(ServerScriptService.modules.SchemaValidator)
+local ServerConfig = require(ServerScriptService.modules.ServerConfig)
 local PlayerStore = {}
 local PlayersDataStore = DataStoreService:GetDataStore("Players")
 local MemoryStoreService   = game:GetService("MemoryStoreService")
 local CacheMap             = MemoryStoreService:GetSortedMap("PlayerDataCache") --:contentReference[oaicite:2]{index=2}
 
-local defaultMaximumGallerySize = 3
+local defaultMaximumGallerySize = ServerConfig.DEFAULT_MAXIMUM_GALLERY_SIZE
 -- TODO: Set this to production value.
-local defaultDrawingTTLAfterPlayerLeft = 10
-local defaultMaximumEnergy = 3
-local defaultMaximumLikeQuota = 10
-local energyRefreshInterval = 60 -- 12 * 60 * 60 -- 12 hours
+local defaultDrawingTTLAfterPlayerLeft = ServerConfig.DEFAULT_DRAWING_TTL_AFTER_PLAYER_LEFT
+local defaultMaximumEnergy = ServerConfig.DEFAULT_MAXIMUM_ENERGY
+local defaultMaximumLikeQuota = ServerConfig.DEFAULT_MAXIMUM_LIKE_QUOTA
+local energyRefreshInterval = ServerConfig.ENERGY_REFRESH_INTERVAL -- 12 * 60 * 60 -- 12 hours
 
 -- Define schema for player data
 local playerDataSchema = SchemaValidator.createSchema({
@@ -43,10 +44,10 @@ export type PlayerData = {
 }
 
 -- tuning ----------------------------------------------------------------
-local CACHE_TTL_SECONDS    = 30*60          -- 30 min cache
-local LOCK_TTL_SECONDS     = 5              -- 5 s mutex
-local LOCK_RETRIES         = 5
-local LOCK_RETRY_DELAY     = 0.4
+local CACHE_TTL_SECONDS    = ServerConfig.CACHE_TTL_SECONDS          -- 30 min cache
+local LOCK_TTL_SECONDS     = ServerConfig.LOCK_TTL_SECONDS           -- 5 s mutex
+local LOCK_RETRIES         = ServerConfig.LOCK_RETRIES
+local LOCK_RETRY_DELAY     = ServerConfig.LOCK_RETRY_DELAY
 -------------------------------------------------------------------------
 
 -- helpers ---------------------------------------------------------------

--- a/src/server/modules/ServerConfig.luau
+++ b/src/server/modules/ServerConfig.luau
@@ -1,0 +1,44 @@
+local ServerConfig = {}
+
+-- Backend configuration
+ServerConfig.BACKEND_BASE_URL = "https://drawing-backend.vercel.app"
+ServerConfig.OPENAI_ENDPOINT = "/api/openai"
+ServerConfig.FEEDBACK_ENDPOINT = "/api/feedback"
+
+-- Debug flag for server modules
+ServerConfig.DEBUG_ENABLED = true
+
+-- Player defaults
+ServerConfig.DEFAULT_MAXIMUM_GALLERY_SIZE = 3
+ServerConfig.DEFAULT_DRAWING_TTL_AFTER_PLAYER_LEFT = 10
+ServerConfig.DEFAULT_MAXIMUM_ENERGY = 3
+ServerConfig.DEFAULT_MAXIMUM_LIKE_QUOTA = 10
+ServerConfig.ENERGY_REFRESH_INTERVAL = 60 -- seconds
+
+-- DataStore/MemoryStore tuning
+ServerConfig.CACHE_TTL_SECONDS = 30 * 60 -- 30 minutes
+ServerConfig.LOCK_TTL_SECONDS = 5
+ServerConfig.LOCK_RETRIES = 5
+ServerConfig.LOCK_RETRY_DELAY = 0.4
+
+-- ClearData script settings
+ServerConfig.CLEAR_DATA = {
+    BATCH_SIZE = 100,
+    YIELD_SECONDS = 0.10,
+    MAX_RETRIES = 5,
+}
+
+-- Admin configuration
+ServerConfig.ADMIN_USER_IDS = {
+    [8240890430] = true,
+}
+
+-- Proximity prompt settings
+ServerConfig.PROMPT = {
+    HOLD_DURATION = 0.5,
+    MAX_ACTIVATION_DISTANCE = 5,
+    TELEPORT_DISTANCE = 2,
+    TELEPORT_HEIGHT = 0,
+}
+
+return ServerConfig

--- a/src/server/modules/TopPlaysStore.luau
+++ b/src/server/modules/TopPlaysStore.luau
@@ -2,11 +2,12 @@ local DataStoreService = game:GetService("DataStoreService")
 local HttpService = game:GetService("HttpService")
 local ServerScriptService = game:GetService("ServerScriptService")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local ServerConfig = require(ServerScriptService.modules.ServerConfig)
 local GameConfig = require(ReplicatedStorage.Modules.GameData.GameConfig)
 local DataStoreHelper = require(ServerScriptService.modules.DataStoreHelper)
 local PlayerBestDrawingsStore = require(ServerScriptService.modules.PlayerBestDrawingsStore)
 local TopPlaysDataStore = DataStoreService:GetDataStore("TopPlays")
-local DEBUG_ENABLED = true
+local DEBUG_ENABLED = ServerConfig.DEBUG_ENABLED
 
 -- Debug print function that only outputs when debugging is enabled
 local function debugPrint(message, ...)


### PR DESCRIPTION
## Summary
- centralize server constants under `ServerConfig`
- reference `ServerConfig` from server scripts
- expose client constants via `GameConfig`
- reference `GameConfig` from client modules

## Testing
- `npm test` *(fails: Missing script)*