### PR TITLE
Update display canvas logic

### DIFF
--- a/src/server/LiveLeaderBoard.server.lua
+++ b/src/server/LiveLeaderBoard.server.lua
@@ -25,6 +25,14 @@ local LB = {}          -- module to return
 local cachedTopScores = nil
 
 LB.MAX_ROWS = MAX_ROWS
+--- Returns the cached list of top scores. The cache will be populated from the
+--  MemoryStore on first request.
+function LB.getCachedTopScores()
+    if cachedTopScores == nil then
+        cachedTopScores = TopMap:GetRangeAsync(Enum.SortDirection.Descending, MAX_ROWS)
+    end
+    return cachedTopScores
+end
 --------------------------------------------------------------------
 -- INTERNAL UTILITIES
 --------------------------------------------------------------------

--- a/src/server/modules/ServerConfig.luau
+++ b/src/server/modules/ServerConfig.luau
@@ -41,4 +41,10 @@ ServerConfig.PROMPT = {
     TELEPORT_HEIGHT = 0,
 }
 
+-- Display canvas settings
+ServerConfig.DISPLAY_CANVAS = {
+    MAX_RANDOM_ATTEMPTS = 5,
+    JOIN_DELAY_SECONDS = 3,
+}
+
 return ServerConfig

--- a/src/server/modules/ServerStates.luau
+++ b/src/server/modules/ServerStates.luau
@@ -9,6 +9,11 @@ ServerStates.CanvasState = {}
 ServerStates.PlayerState = {}
 -- This is a table that contains the playerId to player map.
 ServerStates.PlayerIdToPlayerMap = {}
+-- This table holds the drawings shown on display canvases. Each canvas
+-- instance maps to data that is sent to clients when they join.
+ServerStates.DisplayCanvasDrawings = {}
+-- Fired when DisplayCanvasDrawings has been populated during server start.
+ServerStates.DisplayCanvasDrawingsReadyEvent = Instance.new("BindableEvent")
 
 
 return ServerStates


### PR DESCRIPTION
## Summary
- add configurable display canvas settings in `ServerConfig`
- track when canvases are populated via a bindable event in `ServerStates`
- use configured attempt count when selecting drawings
- wait for drawing cache to populate before sending canvases to new players

## Testing
- `npm test` *(fails: Missing script)*