### PR TITLE
Implement client-side canvas scaling

### DIFF
--- a/src/client/CanvasController.client.lua
+++ b/src/client/CanvasController.client.lua
@@ -1,5 +1,6 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local GameConstants = require(ReplicatedStorage.Modules.GameData.GameConstants)
+local GameConfig   = require(ReplicatedStorage.Modules.GameData.GameConfig)
 local LocalPlayer = game:GetService("Players").LocalPlayer
 local ClientState = require(LocalPlayer:WaitForChild("PlayerScripts"):WaitForChild("ClientState"))
 local Events = ReplicatedStorage:WaitForChild("Events")
@@ -18,6 +19,17 @@ local function GetDeviceTier()
         return "Medium"
     else
         return "Low"
+    end
+end
+
+local function GetPixelsPerStud()
+    local tier = GetDeviceTier()
+    if tier == "High" then
+        return 50
+    elseif tier == "Medium" then
+        return 30
+    else
+        return 15
     end
 end
 
@@ -46,14 +58,14 @@ local function initCanvas(instance)
         canvasId = nil
     }
     
-    -- Wait for the like button with a 5 second timeout
-    local likeButton = waitForChildWhichIsA(instance, "ImageButton", true, 5)
+    -- Wait for the like button with a configurable timeout
+    local likeButton = waitForChildWhichIsA(instance, "ImageButton", true, GameConfig.CANVAS_INIT_TIMEOUT)
     ClientState.DrawingCanvas[instance].likeButton = likeButton
-    
+
     if not likeButton then
         warn("Like button failed to load for canvas:", instance:GetFullName())
         return
-    else 
+    else
         likeButton.Activated:Connect(function()
             local canvasData = ClientState.DrawingCanvas[instance]
             
@@ -77,6 +89,34 @@ local function initCanvas(instance)
             likeButton.BackgroundColor3 = Color3.fromRGB(100, 161, 231)
         end)
     end
+
+    -- Adjust the SurfaceGui's resolution based on device capability
+    task.spawn(function()
+        local board = instance.PrimaryPart
+        if not board then
+            return
+        end
+        local gui = board:WaitForChild("CanvasGui", GameConfig.CANVAS_INIT_TIMEOUT)
+        if gui then
+            local pixelsPerStud = GetPixelsPerStud()
+            gui.PixelsPerStud = pixelsPerStud
+
+            local size = board.Size
+            local widthStuds, heightStuds
+            local face = gui.Face
+            if face == Enum.NormalId.Front or face == Enum.NormalId.Back then
+                widthStuds, heightStuds = size.X, size.Y
+            elseif face == Enum.NormalId.Left or face == Enum.NormalId.Right then
+                widthStuds, heightStuds = size.Z, size.Y
+            else
+                widthStuds, heightStuds = size.X, size.Z
+            end
+
+            local pxW = math.clamp(math.floor(widthStuds * pixelsPerStud), 32, 2048)
+            local pxH = math.clamp(math.floor(heightStuds * pixelsPerStud), 32, 2048)
+            gui.CanvasSize = Vector2.new(pxW, pxH)
+        end
+    end)
 end
 
 local function clearCanvas(canvas)

--- a/src/modules/gameData/GameConfig.lua
+++ b/src/modules/gameData/GameConfig.lua
@@ -10,6 +10,8 @@ local GameConfig = {
     TROPHY_SOUND_ID = "rbxassetid://111277558339395",
     HIGH_SCORE_SOUND_ID = "rbxassetid://79723856625266",
     DEBUG_INPUTUTILS = true,
+    -- Timeouts
+    CANVAS_INIT_TIMEOUT = 5,
 }
 
 return GameConfig


### PR DESCRIPTION
## Summary
- scale `SurfaceGui` pixel density in `CanvasController`
- calculate pixels-per-stud per device tier
- make canvas initialization timeout configurable

## Testing
- `npm test` *(fails: Missing script)*