### PR TITLE
Fix canvas init timing issue

### DIFF
--- a/src/client/CanvasController.client.lua
+++ b/src/client/CanvasController.client.lua
@@ -6,6 +6,7 @@ local Events = ReplicatedStorage:WaitForChild("Events")
 local CommonHelper = require(ReplicatedStorage.Modules.Utils.CommonHelper)
 local CollectionService = game:GetService("CollectionService")
 local NotificationService = require(ReplicatedStorage.Modules.Utils.NotificationService)
+local CanvasUtils = require(ReplicatedStorage.Modules.Utils.CanvasUtils)
 local stopRendering = false
 local initialized = false
 
@@ -104,8 +105,15 @@ local function init()
         metadata: {themeName: string, canvas: Instance, playerId: string, drawingId: string})
         local canvas = metadata.canvas
 
+        -- Wait for the canvas to be registered in ClientState
+        local canvasData = CanvasUtils.waitForCanvasInit(ClientState, canvas)
+        if not canvasData then
+            warn("Canvas failed to initialize for event", canvas:GetFullName())
+            return
+        end
+
         -- Every time a new drawing is drawn, we reset the like button color.
-        local likeButton = ClientState.DrawingCanvas[canvas].likeButton
+        local likeButton = canvasData.likeButton
 
         if likeButton then
             likeButton.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
@@ -114,9 +122,9 @@ local function init()
         CommonHelper.unrenderCanvas(ClientState, canvas)
         -- Set the image data for the canvas.
         if imageData then
-            ClientState.DrawingCanvas[canvas].imageData = imageData
-            ClientState.DrawingCanvas[canvas].playerId = metadata.playerId
-            ClientState.DrawingCanvas[canvas].canvasId = metadata.drawingId
+            canvasData.imageData = imageData
+            canvasData.playerId = metadata.playerId
+            canvasData.canvasId = metadata.drawingId
         else
             clearCanvas(canvas)
         end

--- a/src/client/tests/CanvasUtils.spec.lua
+++ b/src/client/tests/CanvasUtils.spec.lua
@@ -1,0 +1,29 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local CanvasUtils = require(ReplicatedStorage.Modules.Utils.CanvasUtils)
+
+return function()
+    describe("CanvasUtils.waitForCanvasInit", function()
+        it("returns nil when canvas is not initialized in time", function()
+            local state = { DrawingCanvas = {} }
+            local canvas = Instance.new("Model")
+            local start = os.clock()
+            local result = CanvasUtils.waitForCanvasInit(state, canvas, 0.1)
+            expect(result).to.equal(nil)
+            expect(os.clock() - start).to.be.at.least(0.1)
+            canvas:Destroy()
+        end)
+
+        it("returns data once the canvas is initialized", function()
+            local state = { DrawingCanvas = {} }
+            local canvas = Instance.new("Model")
+            task.delay(0.1, function()
+                state.DrawingCanvas[canvas] = {foo = true}
+            end)
+            local result = CanvasUtils.waitForCanvasInit(state, canvas, 1)
+            expect(result).to.be.ok()
+            expect(result.foo).to.equal(true)
+            canvas:Destroy()
+        end)
+    end)
+end
+

--- a/src/modules/gameData/GameConfig.lua
+++ b/src/modules/gameData/GameConfig.lua
@@ -10,6 +10,7 @@ local GameConfig = {
     TROPHY_SOUND_ID = "rbxassetid://111277558339395",
     HIGH_SCORE_SOUND_ID = "rbxassetid://79723856625266",
     DEBUG_INPUTUTILS = true,
+    CANVAS_INIT_TIMEOUT = 5,
 }
 
 return GameConfig

--- a/src/modules/utils/CanvasUtils.luau
+++ b/src/modules/utils/CanvasUtils.luau
@@ -1,0 +1,24 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local GameConfig = require(ReplicatedStorage.Modules.GameData.GameConfig)
+
+local CanvasUtils = {}
+
+--- Waits until the canvas entry in the client state is initialized.
+-- @param clientState table The client state containing DrawingCanvas table.
+-- @param canvas Instance The canvas model.
+-- @param timeout number? Optional timeout in seconds.
+-- @return table? The initialized canvas data or nil on timeout.
+function CanvasUtils.waitForCanvasInit(clientState, canvas: Instance, timeout: number?)
+    timeout = timeout or GameConfig.CANVAS_INIT_TIMEOUT
+    local start = os.clock()
+    while os.clock() - start < timeout do
+        local data = clientState.DrawingCanvas[canvas]
+        if data ~= nil then
+            return data
+        end
+        task.wait(0.1)
+    end
+    return nil
+end
+
+return CanvasUtils


### PR DESCRIPTION
## Summary
- add a small utility to wait for canvas initialization
- use this new helper in `CanvasController.client.lua`
- expose canvas wait timeout in `GameConfig`
- add tests for `CanvasUtils`

## Testing
- `npm test` *(fails: Missing script)*