### PR TITLE
Fix duplicate display drawings

### DIFF
--- a/src/server/GameManager.server.lua
+++ b/src/server/GameManager.server.lua
@@ -15,6 +15,7 @@ local LeaderboardService = require(ServerScriptService.modules.LeaderboardServic
 
 -- Modules
 local CanvasDraw = require(ReplicatedStorage.Modules.Canvas.CanvasDraw)
+local DisplayCanvasSelector = require(ServerScriptService.modules.DisplayCanvasSelector)
 local BackendService = require(ServerScriptService.modules.BackendService)
 local ThemeStore = require(ServerScriptService.modules.ThemeStore)
 local ServerStates = require(ServerScriptService.modules.ServerStates)
@@ -102,25 +103,15 @@ local function populateDisplayCanvases()
         return
     end
 
+    local usedDrawingIds = {}
+
     for _, canvas in pairs(CollectionService:GetTagged("DisplayCanvas")) do
-        local drawing
-        for _ = 1, ServerConfig.DISPLAY_CANVAS.MAX_RANDOM_ATTEMPTS do
-            local entry = topScores[math.random(1, #topScores)]
-            if entry then
-                local uid = tostring(entry.key or entry.value.uid)
-                local topPlays = TopPlaysCacheService.fetch(uid)
-                if topPlays and #topPlays > 0 then
-                    local topPlay = topPlays[math.random(1, #topPlays)]
-                    drawing = {
-                        imageData = CanvasDraw.DecompressImageDataCustom(topPlay.imageData),
-                        themeName = topPlay.theme,
-                        playerId = topPlay.playerId,
-                        drawingId = topPlay.uuid,
-                    }
-                    break
-                end
-            end
-        end
+        local drawing = DisplayCanvasSelector.selectRandomDrawing(
+            topScores,
+            TopPlaysCacheService.fetch,
+            usedDrawingIds,
+            ServerConfig.DISPLAY_CANVAS.MAX_RANDOM_ATTEMPTS
+        )
 
         if drawing then
             ServerStates.DisplayCanvasDrawings[canvas] = drawing

--- a/src/server/modules/DisplayCanvasSelector.luau
+++ b/src/server/modules/DisplayCanvasSelector.luau
@@ -1,0 +1,38 @@
+local CanvasDraw = require(game:GetService("ReplicatedStorage").Modules.Canvas.CanvasDraw)
+local DisplayCanvasSelector = {}
+
+--- Selects a random drawing from the provided top scores while avoiding duplicates.
+-- @param topScores table table of leaderboard entries
+-- @param fetchTopPlays function function(uid) -> table of drawings
+-- @param usedDrawingIds table set of drawing UUIDs already selected
+-- @param maxAttempts number maximum attempts to find a unique drawing
+-- @return table|nil drawing data table or nil if not found
+function DisplayCanvasSelector.selectRandomDrawing(topScores, fetchTopPlays, usedDrawingIds, maxAttempts)
+    assert(topScores, "Missing topScores")
+    assert(fetchTopPlays, "Missing fetchTopPlays function")
+    assert(usedDrawingIds, "Missing usedDrawingIds table")
+    assert(maxAttempts, "Missing maxAttempts")
+
+    for _ = 1, maxAttempts do
+        local entry = topScores[math.random(1, #topScores)]
+        if entry then
+            local uid = tostring(entry.key or entry.value.uid)
+            local topPlays = fetchTopPlays(uid)
+            if topPlays and #topPlays > 0 then
+                local topPlay = topPlays[math.random(1, #topPlays)]
+                if not usedDrawingIds[topPlay.uuid] then
+                    usedDrawingIds[topPlay.uuid] = true
+                    return {
+                        imageData = CanvasDraw.DecompressImageDataCustom(topPlay.imageData),
+                        themeName = topPlay.theme,
+                        playerId = topPlay.playerId,
+                        drawingId = topPlay.uuid,
+                    }
+                end
+            end
+        end
+    end
+    return nil
+end
+
+return DisplayCanvasSelector

--- a/src/server/tests/DisplayCanvasSelector.spec.lua
+++ b/src/server/tests/DisplayCanvasSelector.spec.lua
@@ -1,0 +1,33 @@
+local DisplayCanvasSelector = require(script.Parent.Parent.modules.DisplayCanvasSelector)
+local CanvasDraw = require(game:GetService("ReplicatedStorage").Modules.Canvas.CanvasDraw)
+
+return function()
+    describe("DisplayCanvasSelector.selectRandomDrawing", function()
+        it("avoids returning duplicate drawings", function()
+            -- Stub the decompression to avoid dealing with binary data in tests
+            CanvasDraw.DecompressImageDataCustom = function(data)
+                return data
+            end
+            local topScores = {
+                {key = 1, value = {uid = 1}},
+                {key = 2, value = {uid = 2}},
+            }
+
+            local drawingsByUser = {
+                ["1"] = { {uuid = "a", imageData = "img1", theme = "t", playerId = 1} },
+                ["2"] = { {uuid = "b", imageData = "img2", theme = "t", playerId = 2} },
+            }
+
+            local function fetch(uid)
+                return drawingsByUser[uid]
+            end
+
+            local used = {}
+            local d1 = DisplayCanvasSelector.selectRandomDrawing(topScores, fetch, used, 3)
+            expect(d1).to.be.ok()
+            local d2 = DisplayCanvasSelector.selectRandomDrawing(topScores, fetch, used, 3)
+            expect(d2).to.be.ok()
+            expect(d1.drawingId).never.to.equal(d2.drawingId)
+        end)
+    end)
+end


### PR DESCRIPTION
## Summary
- avoid duplicate drawings on display canvases
- extract selector to `DisplayCanvasSelector` module
- test selector logic

## Testing
- `npm test` *(fails: Missing script)*